### PR TITLE
feat: added render_order to the objects to control when they are sent to the gpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ path = "examples/utils/resource_sharing.rs"
 name = "instancing"
 path = "examples/utils/instancing.rs"
 
+[[example]]
+name = "render_order"
+path = "examples/utils/render_order.rs"
+
 # Development ONLY
 [[example]]
 name = "dev"

--- a/examples/utils/render_order.rs
+++ b/examples/utils/render_order.rs
@@ -1,0 +1,57 @@
+use blue_engine::{primitive_shapes::square, Engine, ObjectSettings};
+
+fn main() {
+    let mut engine = Engine::new().expect("win");
+
+    square(
+        "layer1",
+        ObjectSettings::default(),
+        &mut engine.renderer,
+        &mut engine.objects,
+    )
+    .expect("failed to create square");
+
+    square(
+        "layer2",
+        ObjectSettings::default(),
+        &mut engine.renderer,
+        &mut engine.objects,
+    )
+    .expect("failed to create square");
+
+    let layer1 = engine
+        .objects
+        .get_mut("layer1")
+        .expect("failed to gete object");
+    layer1
+        .set_uniform_color(1f32, 0.5, 0f32, 1f32)
+        .expect("failed to set color");
+    layer1.set_position(-0.5, 0f32, 0f32);
+
+    layer1.set_render_order(0).unwrap();
+
+    let layer2 = engine
+        .objects
+        .get_mut("layer2")
+        .expect("failed to gete object");
+    layer2
+        .set_uniform_color(0f32, 0f32, 1f32, 1f32)
+        .expect("failed to set color");
+    layer2.set_position(0.5, 0f32, 0f32);
+
+    layer2.set_render_order(1).unwrap();
+
+    let start = std::time::SystemTime::now();
+
+    engine
+        .update_loop(move |_, _, object_storage, _, _, _| {
+            let target = object_storage.get_mut("layer1").unwrap();
+
+            if start.elapsed().unwrap().as_secs() % 2 == 0 {
+                target.set_render_order(2).unwrap();
+            } else {
+                target.set_render_order(0).unwrap();
+            }
+        })
+        .expect("Error during update loop");
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -120,6 +120,8 @@ pub struct Object {
     pub uniform_buffers: Vec<wgpu::Buffer>,
     /// Should be rendered or not
     pub is_visible: bool,
+    /// Objects with higher number get rendered later and appear "on top" when occupying the same space
+    pub render_order: usize,
 }
 unsafe impl Send for Object {}
 unsafe impl Sync for Object {}

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -99,6 +99,7 @@ impl Renderer {
                 ),
             ],
             is_visible: true,
+            render_order: 0,
         })
     }
 }
@@ -303,6 +304,15 @@ impl Object {
         self.uniform_color = Array4 {
             data: [red, green, blue, alpha],
         };
+        self.changed = true;
+
+        Ok(())
+    }
+
+    /// Changes the render order of the Object.
+    /// Objects with higher number get rendered later and appear "on top" when occupying the same space
+    pub fn set_render_order(&mut self, render_order: usize) -> anyhow::Result<()> {
+        self.render_order = render_order;
         self.changed = true;
 
         Ok(())

--- a/src/render.rs
+++ b/src/render.rs
@@ -270,7 +270,11 @@ impl Renderer {
         render_pass.set_pipeline(&default_data.1);
         render_pass.set_bind_group(1, &camera.uniform_data, &[]);
 
-        for i in objects.iter() {
+        // sort the object list in descending render order
+        let mut object_list: Vec<_> = objects.iter().collect();
+        object_list.sort_by(|a, b| a.1.render_order.cmp(&b.1.render_order).reverse());
+
+        for i in object_list {
             if i.1.is_visible {
                 let i = i.1;
 


### PR DESCRIPTION
When rendering 2D Scenes it's common to use the render order to control wich objects get rendered on top of each others.
I've added `render_order` to the `Object` struct to control this behaviour.
This works similar to the `z-index` in CSS where a higher `render_order` causes objects to be rendered in front.