### PR TITLE
Signal System

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,7 @@ path = "examples/utils/clear_color.rs"
 [[example]]
 name = "dev"
 path = "examples/dev/dev.rs"
+
+[[example]]
+name = "signals"
+path = "examples/signals.rs"

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -20,24 +20,25 @@ impl Thing {
 
 fn main() {
     let mut a: Signal<Thing, (Vec<u64>, u8)> = Signal::new();
+    
     // You can store objects on the heap or the stack.
     // Both heap & stack pointers can be registered into a delegate.
     let mut heap = Box::new(Thing { total: 300_000 });
-    {
-        let mut stack = Thing { total: 400_000 };
-        // We have lifetime code, if you uncomment the code below it won't compile.
-        // This is because the compiler understands the signal outlives the delegate we're trying to bind.
-        //a.add(&mut stack, Thing::get_total);
-    }
-    a.add(&mut heap, Thing::get_total);
+    let mut stack = Thing { total: 400_000 };
+    a.add(&mut stack, Thing::get_total);
+    a.add( &mut *heap, Thing::get_total);
+    heap.total = 6;
+    a.remove(&*heap, Thing::get_total);
+
+    // Inputs data and broadcasts (executes registered delegates).
     let mut data = (vec![10, 10, 100, 2000], 2);
     a.broadcast(&mut data);
     println!("{}", heap.total);
-
+    println!("{}", stack.total);
 
     // Example code of using single list/struct paramter instead of a tuple.
     let mut b: Signal<Thing, Vec<u64>> = Signal::new();
-    b.add(&mut heap, Thing::mul_tot);
+    b.add(&mut *heap, Thing::mul_tot);
     let mut data = vec![10, 10, 10, 10];
     b.broadcast(&mut data);
     println!("{}", heap.total);

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,0 +1,44 @@
+use blue_engine::signal::Signal;
+
+struct Thing {
+    total: u64,
+}
+
+impl Thing {
+    fn get_total(&mut self, things: &mut (Vec<u64>, u8)) -> () {
+        for thing in things.0.iter() {
+            self.total += thing;
+        }
+    }
+
+    fn mul_tot(&mut self, stuff: &mut Vec<u64>) -> () {
+        for x in stuff.iter() {
+            self.total *= x;
+        }
+    }
+}
+
+fn main() {
+    let mut a: Signal<Thing, (Vec<u64>, u8)> = Signal::new();
+    // You can store objects on the heap or the stack.
+    // Both heap & stack pointers can be registered into a delegate.
+    let mut heap = Box::new(Thing { total: 300_000 });
+    {
+        let mut stack = Thing { total: 400_000 };
+        // We have lifetime code, if you uncomment the code below it won't compile.
+        // This is because the compiler understands the signal outlives the delegate we're trying to bind.
+        //a.add(&mut stack, Thing::get_total);
+    }
+    a.add(&mut heap, Thing::get_total);
+    let mut data = (vec![10, 10, 100, 2000], 2);
+    a.broadcast(&mut data);
+    println!("{}", heap.total);
+
+
+    // Example code of using single list/struct paramter instead of a tuple.
+    let mut b: Signal<Thing, Vec<u64>> = Signal::new();
+    b.add(&mut heap, Thing::mul_tot);
+    let mut data = vec![10, 10, 10, 10];
+    b.broadcast(&mut data);
+    println!("{}", heap.total);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,3 +68,5 @@ pub mod utils;
 pub mod window;
 #[doc(inline)]
 pub use crate::header::*;
+
+pub mod signal;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -32,8 +32,8 @@ impl<This: Any, Args: Sized> Signal<This, Args> {
     /// Enables you to removed registered delegates from a signal.
     pub fn remove(&mut self, object: *const This, callback: fn(&mut This, &mut Args)) {
         for x in 0..self.delegates.len() {
-            if (self.delegates[x].object as *const This) == (object as *const This)
-            && (self.delegates[x].callback as *const fn(&mut This, &mut Args)) == (callback as *const fn(&mut This, &mut Args)) {
+            if (self.delegates[x].object as *const This) == object
+            && self.delegates[x].callback == callback {
                 self.delegates.remove(x);
                 return;
             }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,47 @@
+use std::any::Any;
+
+/// Signal is a type used for creating delegates that can call functions after certain events happen.
+/// None of Signal's internals fields are accessible for safety reasons.
+/// 
+/// You can't access any of the stored delegates because it's not safe and bad practice.
+/// `This` takes a struct type, and `Args` takes a single type as the function parameter. 
+/// `Args` can be a tuple, struct, or list.
+/// 
+/// Whenever you see the word This or this, it's being used as a replacement to mean self.
+pub struct Signal<'a, This: Any, Args: Sized> {
+    delegates: Vec<Delegate<'a, This, Args>>
+}
+
+/// Internal type used for storing delegates.
+struct Delegate<'a, This: Any, Args: Sized> {
+    object: &'a mut This,
+    callback: fn(&mut This, &mut Args) -> (),
+}
+
+impl<'a, This: Any, Args: Sized> Signal<'a, This, Args> {
+    /// Use new to initialize Signal
+    pub fn new() -> Signal<'a, This, Args> {
+        Signal { delegates: Vec::new() }
+    }
+
+    /// Uses this function to register new delegates to the Signal.
+    pub fn add(&mut self, object: &'a mut This, callback: fn(&mut This, &mut Args) -> ()) -> () {
+        self.delegates.push( Delegate { object, callback } );
+    }
+
+    /// Use the function to execute all the registered delegates in the signal.
+    pub fn broadcast(&mut self, parameters: &mut Args) -> () {
+        for obj in self.delegates.iter_mut() {
+            (obj.callback)((*obj).object, parameters);
+            
+            // unsafe code from before I added lifetimes:
+            /*
+            let this = unsafe { 
+                // This is copy-pasted logic from Any::downcast_mut_unchecked because it's locked as unstable feature...
+                &mut *(obj.object.as_mut().unwrap() as *mut dyn Any as *mut This)
+            };
+            (obj.callback)(this, parameters);
+            */
+        }
+    }
+}


### PR DESCRIPTION
Not sure if this is finished or a prototype, but it's in 100% usable state. Just needs some better commenting and example code maybe?

You can not access delegates you have added to the signal, but it does not own any references or mutable references it is given. This means you can use the original pointer of the object instead of having to retrieve it later via downcasting.

I'm unsure if you can achieve undefined behaviour, someone else will need to do extra testing. I tried to create undefined behaviour, but the borrow checker would error at compile-time before running code that would cause undefined behavior.

There is no code to be able to order Signal members, this is because event based code that is registered to a signal shouldn't depend on the execution order of other members. An ordering system wasn't implemented because it adds a lot of extra complexity. If your code does rely on ordering then you shouldn't be using delegates because it's a very bad design choice.

If you do need ordered delegates, this can be achieved by registering 1 delegate to a signal and have it call multiple functions inside. This is the same way I advised logic ordering for Engine::update_loop.