### PR TITLE
Object Rotation Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "blue_engine"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "android_logger",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blue_engine"
-version = "0.5.20"
+version = "0.5.21"
 authors = ["Elham Aryanpur <elhamaryanpur5@gmail.com>"]
 edition = "2021"
 description = "General-Purpose, Easy-to-use, Fast, and Portable graphics engine"

--- a/src/header.rs
+++ b/src/header.rs
@@ -635,6 +635,17 @@ pub enum RotateAxis {
 unsafe impl Send for RotateAxis {}
 unsafe impl Sync for RotateAxis {}
 
+/// Defines how the rotation amount is
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RotateAmount {
+    #[doc(hidden)]
+    Radians(f32),
+    #[doc(hidden)]
+    Degrees(f32),
+}
+unsafe impl Send for RotateAmount {}
+unsafe impl Sync for RotateAmount {}
+
 /// Defines how the texture data is
 #[derive(Debug, Clone)]
 pub enum TextureData {
@@ -755,7 +766,7 @@ pub enum ExecuteOrder {
 pub struct Window {
     /// The winit window itself.
     pub window: Option<std::sync::Arc<crate::winit::window::Window>>,
-    /// Default attributes of the window\
+    /// Default attributes of the window
     pub default_attributes: winit::window::WindowAttributes,
     /// Whether the engine should close.
     pub should_close: bool,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -235,10 +235,6 @@ impl Object {
 
     /// Rotates the object in the axis you specify
     pub fn set_rotatation(&mut self, angle: f32, axis: RotateAxis) -> &mut Self {
-        // The reason for using different transformation matrix is because
-        // of alteration of translation that happens due to rotation. The
-        // solution suggested by https://github.com/tksuoran fixed this through
-        // separating the matrices and multiplying them back at the end.
         let mut rotation_matrix = self.rotation_matrix;
         let axis = match axis {
             RotateAxis::X => {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -10,7 +10,7 @@ use crate::header::{
 };
 use crate::uniform_type::{Array4, Matrix};
 use crate::utils::default_resources::{DEFAULT_MATRIX_4, DEFAULT_SHADER, DEFAULT_TEXTURE};
-use crate::{ObjectStorage, StringBuffer, UnsignedIntType};
+use crate::{ObjectStorage, RotateAmount, StringBuffer, UnsignedIntType};
 
 impl Renderer {
     /// Creates a new object
@@ -234,6 +234,9 @@ impl Object {
     }
 
     /// Rotates the object in the axis you specify
+    ///
+    /// THIS METHOD IS DEPRECATED, USE [crate::Object::set_rotation] or [crate::Object::rotate]
+    #[deprecated]
     pub fn set_rotatation(&mut self, angle: f32, axis: RotateAxis) -> &mut Self {
         let mut rotation_matrix = self.rotation_matrix;
         let axis = match axis {
@@ -252,6 +255,68 @@ impl Object {
         };
 
         rotation_matrix = nalgebra_glm::rotate(&rotation_matrix, angle.to_radians(), &axis);
+        self.rotation_matrix = rotation_matrix;
+        self.inverse_matrices();
+
+        self.changed = true;
+        self
+    }
+
+    /// Sets the rotation of the object in the axis you specify
+    pub fn set_rotation(&mut self, amount: RotateAmount, axis: RotateAxis) -> &mut Self {
+        let mut rotation_matrix = self.rotation_matrix;
+
+        let amount_radians = match amount {
+            RotateAmount::Radians(amount) => amount,
+            RotateAmount::Degrees(amount) => amount.to_radians(),
+        };
+        let axis = match axis {
+            RotateAxis::X => {
+                self.rotation.x = amount_radians;
+                nalgebra_glm::Vec3::x_axis()
+            }
+            RotateAxis::Y => {
+                self.rotation.y = amount_radians;
+                nalgebra_glm::Vec3::y_axis()
+            }
+            RotateAxis::Z => {
+                self.rotation.z = amount_radians;
+                nalgebra_glm::Vec3::z_axis()
+            }
+        };
+
+        rotation_matrix = nalgebra_glm::rotate(&rotation_matrix, amount_radians, &axis);
+        self.rotation_matrix = rotation_matrix;
+        self.inverse_matrices();
+
+        self.changed = true;
+        self
+    }
+
+    /// Rotates the object in the axis you specify
+    pub fn rotate(&mut self, amount: RotateAmount, axis: RotateAxis) -> &mut Self {
+        let mut rotation_matrix = self.rotation_matrix;
+
+        let amount_radians = match amount {
+            RotateAmount::Radians(amount) => amount,
+            RotateAmount::Degrees(amount) => amount.to_radians(),
+        };
+        let axis = match axis {
+            RotateAxis::X => {
+                self.rotation.x += amount_radians;
+                nalgebra_glm::Vec3::x_axis()
+            }
+            RotateAxis::Y => {
+                self.rotation.y += amount_radians;
+                nalgebra_glm::Vec3::y_axis()
+            }
+            RotateAxis::Z => {
+                self.rotation.z += amount_radians;
+                nalgebra_glm::Vec3::z_axis()
+            }
+        };
+
+        rotation_matrix = nalgebra_glm::rotate(&rotation_matrix, amount_radians, &axis);
         self.rotation_matrix = rotation_matrix;
         self.inverse_matrices();
 


### PR DESCRIPTION
* [X] #83 
* [X] Deprecate Object::set_rotatation (I just realized the typo)
* [x] Two new methods:
  * [x] set_rotation
  * [x] rotate